### PR TITLE
Encode frames as jpg before transferring them to the browser

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - jupyter
 - jupyterlab
 - ipython
+- pillow
 - pip
 - pip:
     - python-language-server

--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,7 @@ setup_args = {
     ],
     'install_requires': [
         'ipywidgets>=7.0.0',
+        'pillow>=7.0.0'
     ],
     'packages': find_packages(),
     'zip_safe': False,


### PR DESCRIPTION
Use pillow (PIL) to compress each frame as JPG, then transfer the compressed image encoded as base64. On the browser side, display frames inside an img tag instead of canvas.
The old functionality is still the default; JPG compression can be enabled by setting PVDisplay constructor kwarg compressFrames to True. This can also be set at any later time, so switching between the two transfer modes is always possible.
Adds pillow (PIL) as a dependency!