### PR TITLE
Front-end event rate throttle

### DIFF
--- a/ipyparaview/widgets.py
+++ b/ipyparaview/widgets.py
@@ -38,6 +38,7 @@ class PVDisplay(widgets.DOMWidget):
     frame = Bytes().tag(sync=True)
     resolution = Tuple((800,500)).tag(sync=True) #canvas resolution; w,h
     fpsLimit = Float(60.0).tag(sync=True) #maximum render rate
+    maxEventRate = Float(20.0).tag(sync=True) #maximum number of mouse events/s
 
     # class variables
     instances = dict()
@@ -220,7 +221,6 @@ class PVDisplay(widgets.DOMWidget):
             from dask.distributed import wait
             wait([r.zoomCam(mouseDelta,rlim) for r in self.renderers])
         else:
-
             (self.renv.CameraPosition,
              self.renv.CameraFocalPoint,
              self.renv.CameraViewUp) = zoomCameraTurntable(

--- a/js/lib/widgets.js
+++ b/js/lib/widgets.js
@@ -82,24 +82,43 @@ var PVDisplayView = widgets.DOMWidgetView.extend({
             };
 
 
+            var lastMouseT = Date.now();
+            var wheelAccum = 0.0;
+
+
             // Mouse event handling -- drag and scroll
             function handleDrag(e){
-                view.send({event: 'rotate', 'data': getMouseDelta(e)})
+                t = Date.now();
+                if(t - lastMouseT > 1000.0/model.get('maxEventRate')){
+                    view.send({event: 'rotate', 'data': getMouseDelta(e)});
+                    lastMouseT = t;
+                }
             };
 
             function handleMidDrag(e){
-                view.send({event: 'pan', 'data': getMouseDelta(e)})
+                t = Date.now();
+                if(t - lastMouseT > 1000.0/model.get('maxEventRate')){
+                    view.send({event: 'pan', 'data': getMouseDelta(e)});
+                    lastMouseT = t;
+                }
             };
 
             function handleScroll(e){
-                const wheelScl = 40.0;
+                const wheelScl = 1.0/40.0;
                 const dScl = 0.05;
 
                 e.preventDefault();
                 e.stopPropagation();
-                let d = e.wheelDelta ? e.wheelDelta/wheelScl : e.detail ? -e.detail : 0;
-                if(d){
-                    view.send({event: 'zoom', 'data': 1.0-dScl*d})
+                let d = e.wheelDelta ? e.wheelDelta*wheelScl : e.detail ? -e.detail : 0;
+                wheelAccum += d;
+
+                t = Date.now();
+                if(t - lastMouseT > 1000.0/model.get('maxEventRate')){
+                    if(wheelAccum){
+                        view.send({event: 'zoom', 'data': 1.0-dScl*wheelAccum});
+                    }
+                    wheelAccum = 0.0;
+                    lastMouseT = t;
                 }
             };
 


### PR DESCRIPTION
This PR adds a new attribute to PVDisplay, maxEventRate, that controls how often events are sent from the front-end to the back-end. The event rate throttle helps to prevent events from piling up when render times get too long. Without this, slow rendering leads to laggy interaction as all of the events are queued and handled in sequence.